### PR TITLE
Fix(NO-ISSUE) Update Stripe Webook Var in Example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -129,7 +129,7 @@ export DJANGO_SETTINGS_MODULE=app.settings
 
 # Stripe.
 export STRIPE_SECRET_KEY=
-export STRIPE_ENDPOINT_SECRET=
+export STRIPE_WEBHOOK_SECRET=
 
 # Site.
 SITE_PROTOCOL=http://


### PR DESCRIPTION
Updates the example environment var to the correct version `STRIPE_WEBHOOK_SECRET`