### PR TITLE
Feat(ISSUE-68) Better Order Error Messages

### DIFF
--- a/src/core/forms/order/create_order_session.py
+++ b/src/core/forms/order/create_order_session.py
@@ -6,9 +6,28 @@ from core.services.certificate.group_items import build_child_parent_map
 
 
 class CreateOrderSessionForm(forms.Form):
-    customer_name = forms.CharField(max_length=254, label="Full Name")
-    customer_company_name = forms.CharField(max_length=200, label="Business")
-    property_id = forms.IntegerField(widget=forms.HiddenInput())
+    customer_name = forms.CharField(
+        max_length=254,
+        label="Full Name",
+        error_messages={
+            "required": "A name is required.",
+        },
+    )
+    customer_company_name = forms.CharField(
+        max_length=200,
+        label="Business",
+        error_messages={
+            "required": "A business is required.",
+        },
+    )
+
+    property_id = forms.IntegerField(
+        widget=forms.HiddenInput(),
+        error_messages={
+            "required": "A property is required.",
+        },
+    )
+
     lines = forms.JSONField(
         widget=forms.HiddenInput(),
         error_messages={


### PR DESCRIPTION
https://github.com/wattlehq/mimosa/issues/68

Adds missing required error messaging.

<img width="1624" alt="image" src="https://github.com/user-attachments/assets/f9b33c9d-57e1-428a-895a-2d909263232c">
